### PR TITLE
Fixed README which references Incubator v0.3.0 instead of v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ This repository ships bleeding edge libraries useful for Icinga Web 2 modules.
 Please download the latest release and install it like any other module.
 
 > **HINT**: Do NOT install the GIT master, it will not work! Checking out a
-> branch like `stable/0.3.0` or a tag like `v0.3.0` is fine.
+> branch like `stable/0.5.0` or a tag like `v0.5.0` is fine.
 
 Sample Tarball installation
 ---------------------------
 
 ```sh
 MODULE_NAME=incubator
-MODULE_VERSION=v0.3.0
+MODULE_VERSION=v0.5.0
 MODULES_PATH="/usr/share/icingaweb2/modules"
 MODULE_PATH="${MODULES_PATH}/${MODULE_NAME}"
 RELEASES="https://github.com/Icinga/icingaweb2-module-${MODULE_NAME}/archive"
@@ -27,7 +27,7 @@ Sample GIT installation
 
 ```sh
 MODULE_NAME=incubator
-MODULE_VERSION=v0.3.0
+MODULE_VERSION=v0.5.0
 REPO="https://github.com/Icinga/icingaweb2-module-${MODULE_NAME}"
 MODULES_PATH="/usr/share/icingaweb2/modules"
 git clone ${REPO} "${MODULES_PATH}/${MODULE_NAME}" --branch "${MODULE_VERSION}"
@@ -47,4 +47,4 @@ Developer Documentation
 
 e.g.
 
-    ./bin/make-release.sh 0.3.0
+    ./bin/make-release.sh 0.5.0


### PR DESCRIPTION
When clicking on the (more) field next to incubator, you automatically get to this repo which in the master says to install `v0.3.0`.
Current icingaweb2 installations require to use a higher version. Which (in my case) leads me to frustration.
So I just updated the documentation for the next one. :-)